### PR TITLE
Fix for being unable to write to full terminal width

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
   <groupId>net.trystan</groupId>
   <artifactId>ascii-panel</artifactId>
-  <version>1.1</version>
+  <version>1.2-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/asciiPanel/AsciiPanel.java
+++ b/src/main/java/asciiPanel/AsciiPanel.java
@@ -300,9 +300,9 @@ public class AsciiPanel extends JPanel {
         oldForegroundColors = new Color[widthInCharacters][heightInCharacters];
 
         glyphs = new BufferedImage[256];
-        
+
         loadGlyphs();
-        
+
         AsciiPanel.this.clear();
     }
     
@@ -435,6 +435,7 @@ public class AsciiPanel extends JPanel {
 
     /**
      * Clear the section of the screen with the specified character and whatever the default foreground and background colors are.
+     * The cursor position will not be modified.
      * @param character  the character to write
      * @param x          the distance from the left to begin writing from
      * @param y          the distance from the top to begin writing from
@@ -501,11 +502,16 @@ public class AsciiPanel extends JPanel {
         if (y + height > heightInCharacters)
             throw new IllegalArgumentException("y + height " + (y + height) + " must be less than " + (heightInCharacters + 1) + "." );
 
+        int originalCursorX = cursorX;
+        int originalCursorY = cursorY;
         for (int xo = x; xo < x + width; xo++) {
             for (int yo = y; yo < y + height; yo++) {
                 write(character, xo, yo, foreground, background);
             }
         }
+        cursorX = originalCursorX;
+        cursorY = originalCursorY;
+
         return this;
     }
 
@@ -516,7 +522,7 @@ public class AsciiPanel extends JPanel {
      * @return this for convenient chaining of method calls
      */
     public AsciiPanel write(char character) {
-        if (character < 0 || character >= glyphs.length)
+        if (character < 0 || character > glyphs.length)
             throw new IllegalArgumentException("character " + character + " must be within range [0," + glyphs.length + "]." );
 
         return write(character, cursorX, cursorY, defaultForegroundColor, defaultBackgroundColor);
@@ -635,8 +641,8 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (cursorX + string.length() >= widthInCharacters)
-            throw new IllegalArgumentException("cursorX + string.length() " + (cursorX + string.length()) + " must be less than " + widthInCharacters + "." );
+        if (cursorX + string.length() > widthInCharacters)
+            throw new IllegalArgumentException("cursorX + string.length() " + (cursorX + string.length()) + " must be less than " + widthInCharacters + ".");
 
         return write(string, cursorX, cursorY, defaultForegroundColor, defaultBackgroundColor);
     }
@@ -652,7 +658,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (cursorX + string.length() >= widthInCharacters)
+        if (cursorX + string.length() > widthInCharacters)
             throw new IllegalArgumentException("cursorX + string.length() " + (cursorX + string.length()) + " must be less than " + widthInCharacters + "." );
 
         return write(string, cursorX, cursorY, foreground, defaultBackgroundColor);
@@ -670,7 +676,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (cursorX + string.length() >= widthInCharacters)
+        if (cursorX + string.length() > widthInCharacters)
             throw new IllegalArgumentException("cursorX + string.length() " + (cursorX + string.length()) + " must be less than " + widthInCharacters + "." );
 
         return write(string, cursorX, cursorY, foreground, background);
@@ -688,7 +694,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (x + string.length() >= widthInCharacters)
+        if (x + string.length() > widthInCharacters)
             throw new IllegalArgumentException("x + string.length() " + (x + string.length()) + " must be less than " + widthInCharacters + "." );
 
         if (x < 0 || x >= widthInCharacters)
@@ -713,7 +719,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (x + string.length() >= widthInCharacters)
+        if (x + string.length() > widthInCharacters)
             throw new IllegalArgumentException("x + string.length() " + (x + string.length()) + " must be less than " + widthInCharacters + "." );
 
         if (x < 0 || x >= widthInCharacters)
@@ -739,7 +745,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null." );
         
-        if (x + string.length() >= widthInCharacters)
+        if (x + string.length() > widthInCharacters)
             throw new IllegalArgumentException("x + string.length() " + (x + string.length()) + " must be less than " + widthInCharacters + "." );
 
         if (x < 0 || x >= widthInCharacters)
@@ -771,7 +777,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (string.length() >= widthInCharacters)
+        if (string.length() > widthInCharacters)
             throw new IllegalArgumentException("string.length() " + string.length() + " must be less than " + widthInCharacters + "." );
 
         int x = (widthInCharacters - string.length()) / 2;
@@ -794,7 +800,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null" );
 
-        if (string.length() >= widthInCharacters)
+        if (string.length() > widthInCharacters)
             throw new IllegalArgumentException("string.length() " + string.length() + " must be less than " + widthInCharacters + "." );
 
         int x = (widthInCharacters - string.length()) / 2;
@@ -818,7 +824,7 @@ public class AsciiPanel extends JPanel {
         if (string == null)
             throw new NullPointerException("string must not be null." );
 
-        if (string.length() >= widthInCharacters)
+        if (string.length() > widthInCharacters)
             throw new IllegalArgumentException("string.length() " + string.length() + " must be less than " + widthInCharacters + "." );
 
         int x = (widthInCharacters - string.length()) / 2;

--- a/src/test/java/asciiPanel/AsciiPanelTest.java
+++ b/src/test/java/asciiPanel/AsciiPanelTest.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
 import javax.swing.JComponent;
-import javax.swing.JPanel;
 import javax.swing.UIManager;
 import javax.swing.plaf.PanelUI;
 import org.junit.runner.RunWith;
@@ -71,6 +70,18 @@ public class AsciiPanelTest {
     fail("Should have thrown an IllegalArgumentException.");
   }
 
+  @Test
+  public void testSetCursorX() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.setCursorX(0);
+  }
+
+  @Test
+  public void testSetCursorY() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.setCursorY(0);
+  }
+
   @Test( expected = NullPointerException.class )
   public void testSetNullDefaultBackgroundColor() {
     AsciiPanel panel = new AsciiPanel();
@@ -111,8 +122,99 @@ public class AsciiPanelTest {
   @Test( expected = IllegalArgumentException.class )
   public void testWriteInvalidLengthFail() {
     AsciiPanel panel = new AsciiPanel(80, 1);
-    String superLongString = " ";    
+    String superLongString = " ";
     panel.write(superLongString);
     fail("Should have thrown an IllegalArgumentException.");
   }
+
+  @Test
+  public void testWriteChar() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(' ');
+  }
+
+  @Test
+  public void testWriteCharFG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(' ', AsciiPanel.white);
+  }
+
+  @Test
+  public void testWriteCharFGBG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(' ', AsciiPanel.white, AsciiPanel.black);
+  }
+
+  @Test
+  public void testWriteCharXY() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(' ', 0, 0);
+  }
+
+  @Test
+  public void testWriteCharXYFG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(' ', 0, 0, AsciiPanel.white);
+  }
+
+  @Test
+  public void testWriteCharXYFGBG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(' ', 0, 0, AsciiPanel.white, AsciiPanel.black);
+  }
+
+  @Test
+  public void testWriteString() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(" ");
+  }
+
+  @Test
+  public void testWriteStringFG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(" ", AsciiPanel.white);
+  }
+
+  @Test
+  public void testWriteStringFGBG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(" ", AsciiPanel.white, AsciiPanel.black);
+  }
+
+  @Test
+  public void testWriteStringXY() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(" ", 0, 0);
+  }
+
+  @Test
+  public void testWriteStringXYFG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(" ", 0, 0, AsciiPanel.white);
+  }
+
+  @Test
+  public void testWriteStringXYFGBG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.write(" ", 0, 0, AsciiPanel.white, AsciiPanel.black);
+  }
+
+  @Test
+  public void testWriteCenter() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.writeCenter(" ", 0);
+  }
+
+  @Test
+  public void testWriteCenterFG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.writeCenter(" ", 0, AsciiPanel.white);
+  }
+
+  @Test
+  public void testWriteCenterFGBG() {
+    AsciiPanel panel = new AsciiPanel(1, 1);
+    panel.writeCenter(" ", 0, AsciiPanel.white, AsciiPanel.black);
+  }
+
 }


### PR DESCRIPTION
IllegalArgumentExceptions were being thrown when `cursorX + length >= widthInCharacters`,
but this restricts the writable width to widthInCharacters - 1. In the trivial case of
a 1x1 panel, writing a one-character string would always throw. Changed the logic to allow
an additional character of width.

This change will also restore the previous cursor position after a `clear()`. Because
clear() uses write(), which updates the cursor position, a newly-initialized panel
would throw an exception if the user attempted to write to what they would assume
is a default of 0, 0.