### PR TITLE
Feature/ascii font class

### DIFF
--- a/src/main/java/asciiPanel/AsciiFont.java
+++ b/src/main/java/asciiPanel/AsciiFont.java
@@ -37,7 +37,7 @@ public class AsciiFont {
 		return height;
 	}
 
-	AsciiFont(String filename, int width, int height) {
+	public AsciiFont(String filename, int width, int height) {
 		this.fontFilename = filename;
 		this.width = width;
 		this.height = height;

--- a/src/main/java/asciiPanel/AsciiFont.java
+++ b/src/main/java/asciiPanel/AsciiFont.java
@@ -7,18 +7,17 @@ package asciiPanel;
  * @author zn80
  *
  */
-public enum AsciiFont {
+public class AsciiFont {
 
-	CP437_8x8("cp437_8x8.png", 8, 8),
-	CP437_10x10("cp437_10x10.png", 10, 10),
-	CP437_12x12("cp437_12x12.png", 12, 12),
-	CP437_16x16("cp437_16x16.png", 16, 16),
-	CP437_9x16("cp437_9x16.png", 9, 16),
-	DRAKE_10x10("drake_10x10.png", 10, 10),
-	TAFFER_10x10("taffer_10x10.png", 10, 10),
-	QBICFEET_10x10("qbicfeet_10x10.png", 10, 10),
-	TALRYTH_15_15("talryth_square_15x15.png", 15, 15);
-	
+	public static final AsciiFont CP437_8x8 = new AsciiFont("cp437_8x8.png", 8, 8);
+	public static final AsciiFont CP437_10x10 = new AsciiFont("cp437_10x10.png", 10, 10);
+	public static final AsciiFont CP437_12x12 = new AsciiFont("cp437_12x12.png", 12, 12);
+	public static final AsciiFont CP437_16x16 = new AsciiFont("cp437_16x16.png", 16, 16);
+	public static final AsciiFont CP437_9x16 = new AsciiFont("cp437_9x16.png", 9, 16);
+	public static final AsciiFont DRAKE_10x10 = new AsciiFont("drake_10x10.png", 10, 10);
+	public static final AsciiFont TAFFER_10x10 = new AsciiFont("taffer_10x10.png", 10, 10);
+	public static final AsciiFont QBICFEET_10x10 = new AsciiFont("qbicfeet_10x10.png", 10, 10);
+	public static final AsciiFont TALRYTH_15_15 = new AsciiFont("talryth_square_15x15.png", 15, 15);
 	
 	private String fontFilename;
 


### PR DESCRIPTION
I believe `enum` was too restrictive for AsciiFont. Simply promoting it to `class` allows we users to provide our own "fonts".

For backward compatibility, I preserved each of the prefabs as a `public static final` instance of AsciiFont.