### PR TITLE
Fixed a race condition in the AsciiPanel paint method

### DIFF
--- a/src/main/java/asciiPanel/AsciiPanel.java
+++ b/src/main/java/asciiPanel/AsciiPanel.java
@@ -347,21 +347,22 @@ public class AsciiPanel extends JPanel {
 
         for (int x = 0; x < widthInCharacters; x++) {
             for (int y = 0; y < heightInCharacters; y++) {
-            	if (oldBackgroundColors[x][y] == backgroundColors[x][y]
-            	 && oldForegroundColors[x][y] == foregroundColors[x][y]
-            	 && oldChars[x][y] == chars[x][y])
+                char newCharacter = chars[x][y];
+                Color newBackgroundColor = backgroundColors[x][y];
+                Color newForegroundColor = foregroundColors[x][y];
+
+            	if (oldBackgroundColors[x][y] == newBackgroundColor
+            	 && oldForegroundColors[x][y] == newForegroundColor
+            	 && oldChars[x][y] == newCharacter)
             		continue;
             	
-                Color bg = backgroundColors[x][y];
-                Color fg = foregroundColors[x][y];
-
-                LookupOp op = setColors(bg, fg);
-                BufferedImage img = op.filter(glyphs[chars[x][y]], null);
+                LookupOp op = setColors(newBackgroundColor, newForegroundColor);
+                BufferedImage img = op.filter(glyphs[newCharacter], null);
                 offscreenGraphics.drawImage(img, x * charWidth, y * charHeight, null);
                 
-                oldBackgroundColors[x][y] = backgroundColors[x][y];
-        	    oldForegroundColors[x][y] = foregroundColors[x][y];
-        	    oldChars[x][y] = chars[x][y];
+                oldBackgroundColors[x][y] = newBackgroundColor;
+        	    oldForegroundColors[x][y] = newForegroundColor;
+        	    oldChars[x][y] = newCharacter;
             }
         }
         


### PR DESCRIPTION
## The Problem

I discovered a race condition that can result within the `paint` method of the `AsciiPanel` class. The code below will reliably reproduce it:
```java
import asciiPanel.AsciiCharacterData;
import asciiPanel.AsciiPanel;

import javax.swing.*;
import java.awt.*;

class Frame extends JFrame {
    private AsciiPanel asciiPanel;

    public Frame(int width, int height) {
        asciiPanel = new AsciiPanel(width, height);
        setVisible(true);
        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
        add(asciiPanel);
        pack();
        repaint();
    }

    public void fill(AsciiCharacterData charData) {
        for (int x = 0; x < asciiPanel.getWidthInCharacters(); x++) {
            for (int y = 0; y < asciiPanel.getHeightInCharacters(); y++) {
                asciiPanel.write(charData.character, x, y, charData.foregroundColor, charData.backgroundColor);
            }
        }
    }

    public void clear() {
        asciiPanel.clear();
    }

    public void refresh() {
        asciiPanel.repaint();
    }
}

public class Main {
    public static void main(String[] args) {
        AsciiCharacterData charData = new AsciiCharacterData();
        charData.character = '#';
        charData.foregroundColor = Color.white;
        charData.backgroundColor = Color.black;
        Frame frame = new Frame(200, 40);
        int timePerLoop = 1000000000 / 60;

        while(true) {
            long startTime = System.nanoTime();
            frame.clear();
            frame.fill(charData);
            frame.refresh();
            long endTime = System.nanoTime();
            long sleepTime = timePerLoop - (endTime-startTime);

            if (sleepTime > 0) {
                try {
                    Thread.sleep(sleepTime / 1000000);
                } catch (InterruptedException ignored) {
                }
            }
        }
    }
}
```
You would expect to see a terminal filled entirely with white `#` symbols, but instead you'll get something like:
![race_condition](https://user-images.githubusercontent.com/5762006/174958154-967d3143-634f-408a-bd5b-552c9c42d247.png)

This is due to the timing of the `paint` operations as scheduled by AWT. It's easiest to understand by looking at the `AsciiPanel.paint` code.

**Existing `paint` code, comments added by me**:
```java
    @Override
    public void paint(Graphics g) {
        if (g == null)
            throw new NullPointerException();

        for (int x = 0; x < widthInCharacters; x++) {
            for (int y = 0; y < heightInCharacters; y++) {
                
                // A

            	if (oldBackgroundColors[x][y] == backgroundColors[x][y]
            	 && oldForegroundColors[x][y] == foregroundColors[x][y]
            	 && oldChars[x][y] == chars[x][y])
            		continue;
            	
                Color bg = backgroundColors[x][y];
                Color fg = foregroundColors[x][y];

                LookupOp op = setColors(bg, fg);
                BufferedImage img = op.filter(glyphs[chars[x][y]], null);

                // B 

                offscreenGraphics.drawImage(img, x * charWidth, y * charHeight, null);
                
               // C
 
                oldBackgroundColors[x][y] = backgroundColors[x][y];
        	oldForegroundColors[x][y] = foregroundColors[x][y];
        	oldChars[x][y] = chars[x][y];
            }
        }
        
        g.drawImage(offscreenBuffer,0,0,this);
    }
```

At point **A**, the paint function (on some AWT UI thread) has reached the character at (x, y). It compares this to what was previously drawn on the offscreen buffer, and if it's not the exact same character, foreground color, and background color as was previously written, we know we need to write this new character out. For the sake of example, let's say the previously written out character was a `#` character, with white foreground and black background. The new value at (x, y) is a ` ` space character, with white foreground and black background. As such, we know we need to write out this new character to the offscreen buffer.

At point **B**, we've actually finalized the values were going to write out, because we've got the foreground color, background color, and glyph saved in local variables (the glyph via the filter object). 

Now imagine that some other thread (in our reproduction above, the main application thread) writes to the character at (x, y) sometime after **B** and before **C**. We'll say it writes a '%' with white foreground and a blue background. At point **C**, we update the previously written out character data to say what is currently on the offscreen buffer, to save ourselves work if the value doesn't change. Except we aren't specifying the local variables that actually contain what we wrote out, but are referencing the grids of character data that were written to by this other thread. As such, we drew out a ` ` (blank space) with black background, but we record that we drew out `%` with white foreground and blue background. Assuming (x, y) isn't written before the next time paint is invoked again, we'll look at the current character data for (x, y), see a `%` with white foreground and blue background, and see that that matches what we recorded in the previously written character data, and not go through the work of redrawing this section of the offscreen buffer. Except what's actually on that buffer is a blank space with black background. This character tile will be "stuck" until we change it's value to something else.

## My Solution
There are a few ways to go about fixing this problem. The heaviest hammer would be to use a mutex to protect access to the character data within the write and paint methods, but this could unduly impact performance in applications that are attempting repaint rapidly (e.g. the 60FPS repro code above). Another option would be to leverage immutable data structures to hold the character data, but doing so in a memory efficient manner is non-trivial.

The solution I implemented here is the most obvious and simplest solution, I think. Basically I just grab the "current" character and colors at one point in the paint method, write these out, and then update the previously written out character data with the values that we _know_ we just wrote out. There's still a potential data race where maybe somebody wrote to that character while I was pulling the values and I have, say, the new character but the old background and foreground colors (so things would look wonky for one repaint interval), but the next time paint is called we'll see that the fully updated new value doesn't match what we wrote out, and rewrite the value. I imagine there's probably a scenario where this could be problematic, this solution is good enough for most cases I think (and certainly doesn't make anything worse).

With the changes implemented, when I rerun the reproduction code above, the output is correct:

![race_condition_fixed](https://user-images.githubusercontent.com/5762006/174958211-a5c47cbc-d25c-42da-be6a-3353e8c19f91.png)

